### PR TITLE
fix: redirect to path without trailing slash

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "rewrites": [
     { "source": "/docs/:path*", "destination": "https://parca-docs.vercel.app/docs/:path*" }
-  ]
+  ],
+  "trailingSlash": false
 }


### PR DESCRIPTION
Currently, any paths with a trailing slash return 404:

```console
$ curl --fail https://www.parca.dev/docs/
curl: (22) The requested URL returned error: 404

$ curl --fail https://www.parca.dev/docs/overview/
curl: (22) The requested URL returned error: 404
```

Reference: [vercel.com/docs/project-configuration#project-configuration/trailing-slash](https://vercel.com/docs/project-configuration#project-configuration/trailing-slash)